### PR TITLE
set ARG TERM and ARG DEBIAN_FRONTEND to prevent useless error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:wheezy-backports
 
+ARG TERM=linux
+ARG DEBIAN_FRONTEND=noninteractive
+
 # restyaboard version
 ENV restyaboard_version=v0.2.1
 


### PR DESCRIPTION
More info can be found in [docker issue #4032](https://github.com/docker/docker/issues/4032#issuecomment-46128765)
Remove errors such as:

> debconf: unable to initialize frontend: Dialog
> debconf: (TERM is not set, so the dialog frontend is not usable.)
> debconf: falling back to frontend: Readline
> debconf: unable to initialize frontend: Readline
> debconf: (This frontend requires a controlling tty.)
> debconf: falling back to frontend: Teletype
